### PR TITLE
Adding no color diagonal in swatches trigger

### DIFF
--- a/src/Swatch.vue
+++ b/src/Swatch.vue
@@ -118,19 +118,6 @@ export default {
 
     .vue-swatches__diagonal--wrapper {
       position: absolute;
-      width: 100%;
-      height: 100%;
-    }
-    .vue-swatches__diagonal {
-      width: 75%;
-      height: 75%;
-      background:
-        linear-gradient(to top right,
-        rgba(0,0,0,0) 0%,
-        rgba(0, 0, 0, 0) calc(50% - 2.4px),
-        rgba(222, 8, 10, 1) 50%,
-        rgba(0,0,0,0) calc(50% + 2.4px),
-        rgba(0,0,0,0) 100%);
     }
   }
 </style>

--- a/src/Swatches.vue
+++ b/src/Swatches.vue
@@ -9,7 +9,12 @@
           class="vue-swatches__trigger"
           :class="{ 'vue-swatches--is-empty': !value, 'vue-swatches--is-disabled': disabled }"
           :style="triggerStyles"
-        ></div>
+        >
+        <div v-if="isNoColor" class="vue-swatches__diagonal--wrapper vue-swatches--has-children-centered">
+          <div class="vue-swatches__diagonal"></div>
+        </div>
+      </div>
+
       </slot>
     </div>
 
@@ -225,6 +230,9 @@ export default {
     isOpen () {
       if (this.inline) return false
       return this.internalIsOpen
+    },
+    isNoColor () {
+      return this.checkEquality('', this.internalValue)
     },
 
     /** REAL COMPUTEDS (depends on user's props and preset's values, these have 'computed' prefix) **/
@@ -535,5 +543,21 @@ export default {
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  .vue-swatches__diagonal--wrapper {
+    width: 100%;
+    height: 100%;
+  }
+  .vue-swatches__diagonal {
+    width: 75%;
+    height: 75%;
+    background:
+      linear-gradient(to top right,
+      rgba(0,0,0,0) 0%,
+      rgba(0, 0, 0, 0) calc(50% - 2.4px),
+      rgba(222, 8, 10, 1) 50%,
+      rgba(0,0,0,0) calc(50% + 2.4px),
+      rgba(0,0,0,0) 100%);
   }
 </style>

--- a/src/Swatches.vue
+++ b/src/Swatches.vue
@@ -10,7 +10,7 @@
           :class="{ 'vue-swatches--is-empty': !value, 'vue-swatches--is-disabled': disabled }"
           :style="triggerStyles"
         >
-        <div v-if="isNoColor" class="vue-swatches__diagonal--wrapper vue-swatches--has-children-centered">
+        <div v-show="isNoColor" class="vue-swatches__diagonal--wrapper vue-swatches--has-children-centered">
           <div class="vue-swatches__diagonal"></div>
         </div>
       </div>

--- a/test/unit/specs/props.spec.js
+++ b/test/unit/specs/props.spec.js
@@ -200,7 +200,7 @@ describe('Props', () => {
               colors
             }
           })
-          const diagonal = componentWrapper.find('.vue-swatches__diagonal--wrapper')
+          const diagonal = componentWrapper.find('.vue-swatches__swatch .vue-swatches__diagonal--wrapper')
           return Vue.nextTick()
           .then(() => {
             expect(diagonal.exists())
@@ -254,6 +254,21 @@ describe('Props', () => {
         .then(() => {
           expect(swatchesColors)
           .toEqual(rgbColors)
+        })
+      })
+      test('it should render a diagonal in the trigger', () => {
+        const colors = ['', '#a156e2', '#eca23e']
+        const componentWrapper = mount(Swatches, {
+          propsData: {
+            colors,
+            value: ''
+          }
+        })
+        const diagonal = componentWrapper.find('.vue-swatches__trigger').find('.vue-swatches__diagonal--wrapper')
+        return Vue.nextTick()
+        .then(() => {
+          expect(diagonal.isVisible())
+          .toBeTruthy()
         })
       })
     })


### PR DESCRIPTION
If no color is selected, the swatches trigger shows the red diagonal.

Code comments:
* Common styles have been moved up (from Swatch to Swatches component).
* Diagonal position fix is preserved at Swatch component