### PR TITLE
Prevent the fallback button to submit a form.

### DIFF
--- a/src/Swatches.vue
+++ b/src/Swatches.vue
@@ -92,7 +92,7 @@
           <button
             class="vue-swatches__fallback__button"
             :class="fallbackOkClass"
-            @click="onFallbackButtonClick"
+            @click.prevent="onFallbackButtonClick"
           >
             {{ fallbackOkText }}
           </button>


### PR DESCRIPTION
Buttons have the default behaviour of submitting a form. The fallback "save" button will also trigger a form submit if the swatches element is being used in a form element.