### PR TITLE
Fix misspelling in documentation

### DIFF
--- a/documentation/_examples/_examples.pug
+++ b/documentation/_examples/_examples.pug
@@ -15,7 +15,7 @@
 
   +subsection('Custom Colors')
     :markdown-it
-      Remeber to use always **6-digits** hexadecimal colors.
+      Remember to use always **6-digits** hexadecimal colors.
 
       If you want to provide a **transparent/no-color** option you can use a empty string (`''`).
     +example('CustomColors', { showJavascript: true })


### PR DESCRIPTION
Replace 'Remeber' with 'Remember'