### PR TITLE
Add vue extension when importing components

### DIFF
--- a/src/VSwatch.vue
+++ b/src/VSwatch.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script>
-import VCheck from "./VCheck";
+import VCheck from "./VCheck.vue";
 
 export default {
   name: "v-swatch",

--- a/src/VSwatches.vue
+++ b/src/VSwatches.vue
@@ -138,7 +138,7 @@ import basicPreset from "./presets/basic";
 import textBasicPreset from "./presets/text-basic";
 import textAdvancedPreset from "./presets/text-advanced";
 
-import VSwatch from "./VSwatch";
+import VSwatch from "./VSwatch.vue";
 
 export const DEFAULT_BACKGROUND_COLOR = "#ffffff";
 export const DEFAULT_BORDER_RADIUS = "10px";


### PR DESCRIPTION
When working with Vue 3 with Vite instead of webpack, one can import the components from source but it breaks because the imports don't include the file extension.

With these changes, one can:

```javascript
<template>
  ...
</template>

<script>
import VSwatches from 'vue-swatches/src/VSwatches.vue'

...
</script>
```

And use the swatches